### PR TITLE
Switch to gacts/install-dnscontrol and add import workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install dnscontrol
+        uses: gacts/install-dnscontrol@v1
+
       - name: DNSControl push
-        id: dnscontrol_preview
-        uses: is-cool-me/dnscontrol-action@v4.8.2
-        with:
-          args: push
         env:
           CLOUDFLARE_APITOKEN: ${{ secrets.CLOUDFLARE_APITOKEN }}
+        run: dnscontrol push

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -1,0 +1,65 @@
+# Author: Luka Kladaric @allixsenos
+
+name: Import zones from Cloudflare
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dnscontrol
+        uses: gacts/install-dnscontrol@v1
+
+      - name: Sync all zones from Cloudflare
+        env:
+          CLOUDFLARE_APITOKEN: ${{ secrets.CLOUDFLARE_APITOKEN }}
+        run: |
+          zones=$(dnscontrol get-zones --format=nameonly cloudflare - all | sort)
+
+          while IFS= read -r zone; do
+            [ -z "$zone" ] && continue
+            echo "Exporting zone: $zone"
+            dnscontrol get-zones --format=js cloudflare - "$zone" > "zones/${zone}.js"
+          done <<< "$zones"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain zones/)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Sync zones from Cloudflare"
+          title: "Sync zones from Cloudflare"
+          body: |
+            ## Zone Sync
+
+            This PR syncs zone configurations from Cloudflare. Review the diff to see:
+            - New zones added
+            - Changes to existing zones (records added/modified/removed on Cloudflare but not in repo)
+
+            ## Review Checklist
+            - [ ] Review the zone changes in the diff
+            - [ ] Verify the changes match expected state
+            - [ ] Check for any sensitive records that should be removed
+          branch: sync/cloudflare-zones
+          delete-branch: true
+
+      - name: No changes summary
+        if: steps.changes.outputs.has_changes != 'true'
+        run: echo "No changes detected. All zones are in sync with Cloudflare."

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,22 +14,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install dnscontrol
+        uses: gacts/install-dnscontrol@v1
+
       - name: DNSControl check
         id: dnscontrol_check
-        uses: is-cool-me/dnscontrol-action@v4.8.2
-        with:
-          args: check
         env:
-          NO_COLOR: yes # disable colors
+          NO_COLOR: "1"
+        run: |
+          output=$(dnscontrol check 2>&1) || true
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$output" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: DNSControl preview
         id: dnscontrol_preview
-        uses: is-cool-me/dnscontrol-action@v4.8.2
-        with:
-          args: preview
         env:
-          NO_COLOR: yes # disable colors
+          NO_COLOR: "1"
           CLOUDFLARE_APITOKEN: ${{ secrets.CLOUDFLARE_APITOKEN }}
+        run: |
+          output=$(dnscontrol preview 2>&1) || true
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$output" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Preview pull request comment
         uses: thollander/actions-comment-pull-request@v2


### PR DESCRIPTION
## Summary
- Replace `is-cool-me/dnscontrol-action` with `gacts/install-dnscontrol`
- Add manually triggered import workflow to sync zones from Cloudflare
- Remove version pin to always use latest dnscontrol

## Changes

### deploy.yml & preview.yml
- Use `gacts/install-dnscontrol@v1` to install dnscontrol
- Run dnscontrol commands directly instead of through action wrapper

### import.yml (new)
Manually triggered workflow that:
1. Fetches all zones from Cloudflare account
2. Exports each zone to a JS file in `zones/`
3. Creates a PR with any changes for review

## Why
- `gacts/install-dnscontrol` is more reliable and actively maintained
- Direct command execution gives more control over output capture
- Import workflow helps sync existing Cloudflare zones into the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)