### PR TITLE
Remove END macro from example zone

### DIFF
--- a/zones/example.com.js
+++ b/zones/example.com.js
@@ -25,6 +25,4 @@ D("example.com", NewRegistrar("none"), DnsProvider(DNS_CFLARE),
     // G Suite setup
     MX('@', 1, 'smtp.google.com.'),
 	TXT("google._domainkey", "v=DKIM1; k=rsa; p=asdfblahblah"),
-
-	END  // alias to fix trailing comma issue because javascript is a silly language choice for a configuration file
 )


### PR DESCRIPTION
## Summary
Remove the `END` macro workaround from the example zone file.

## Why
The `D()` constructor now supports trailing commas, so the `END` workaround is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)