### PR TITLE
ci: guard template workflows from running in the template repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   push:
+    if: github.repository != 'awesome-foundation/dns' # Do not run in the template repository — you may delete this line, it has no effect in your repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   import:
+    if: github.repository != 'awesome-foundation/dns' # Do not run in the template repository — you may delete this line, it has no effect in your repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   preview:
+    if: github.repository != 'awesome-foundation/dns' # Do not run in the template repository — you may delete this line, it has no effect in your repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Adds template repo guard to all workflow jobs so they skip execution in the template repo
- Each guard has an inline comment explaining users can safely delete the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)